### PR TITLE
[FIX] build break caused by TKClass macro

### DIFF
--- a/ThemeKit/ThemeKit/Models/TKGradientStop.m
+++ b/ThemeKit/ThemeKit/Models/TKGradientStop.m
@@ -189,7 +189,7 @@
 
 - (id)init {
     if ((self = [super init])) {
-        self.backingStop = [[TKClass(CUIPSDGradientStop) alloc] initWithLocation:0.0];
+        self.backingStop = [[CUIPSDGradientStop alloc] initWithLocation:0.0];
     }
     
     return self;


### PR DESCRIPTION
TKClass macro removed the type of CUIPSDGradientStop. This will cause the build to failed, because clang won't be able to find the correct -initWithLocation: method.